### PR TITLE
Filter dropdown statuses and labels

### DIFF
--- a/inc/admin/classes/class-wp-statuses-admin.php
+++ b/inc/admin/classes/class-wp-statuses-admin.php
@@ -390,7 +390,7 @@ class WP_Statuses_Admin {
 			return;
 		}
 
-		$statuses = wp_statuses_get_statuses( $post->post_type );
+		$statuses = apply_filters( 'wp_statuses_get_statuses', wp_statuses_get_statuses( $post->post_type ) );
 
 		$options        = array( '<select name="post_status" id="wp-statuses-dropdown">' );
 		$dashicon       = 'dashicons-post-status';

--- a/inc/core/classes/class-wp-statuses-core-status.php
+++ b/inc/core/classes/class-wp-statuses-core-status.php
@@ -237,6 +237,8 @@ class WP_Statuses_Core_Status {
 			),
 		);
 
+		$labels = apply_filters( 'wp_statuses_labels', $labels );
+
 		if ( ! isset( $labels[ $name ] ) ) {
 			return null;
 		}


### PR DESCRIPTION
I was wondering if it might be possible to add some filters to wp_statuses. Two in particular would be helpful for me right now.

(1) filter which statuses are displayed in the metabox dropdown. Some of WordPress's built in statuses aren't relevant for me, so it would avoid confusion with editors on the site if they were removed. Although it's possible to achieve the same with javascript, a simple filter seems to be an easier and more robust way to achieve this.

(2) filter the labels used for the built in status types. I'd prefer slightly different wording to what you have used, so a filter would be the simplest way to change the labels.

This commit could probably be improved and if you are willing to add some filters, then there may be other similar things which could also be filtered.

For the record the capitalisation of words isn't consistent in some of the labels, specifically `Publicly published` and `Save as private` (lines 206 and 221 of class-wp-statuses-core-status.php).