### PR TITLE
Fix PHP warnings for scheduled posts

### DIFF
--- a/inc/admin/classes/class-wp-statuses-admin.php
+++ b/inc/admin/classes/class-wp-statuses-admin.php
@@ -247,7 +247,9 @@ class WP_Statuses_Admin {
 			$status = 'draft';
 		} elseif ( ! empty( $post->post_password ) ) {
 			$status = 'password';
-		}
+		} elseif ( 'future' === $status ) {
+		    $status = 'publish';
+        }
 
 		// Get the customizable labels
 		$statuses_labels = wp_statuses_get_metabox_labels( $post->post_type );


### PR DESCRIPTION
If I set a post to publish in the future, the publish meta_box throws a couple of errors when getting labels for the meta_box:

```
Notice: Undefined index: future in /app/public/wp-content/plugins/wp-statuses/inc/admin/classes/class-wp-statuses-admin.php on line 546
Notice: Undefined index: future in /app/public/wp-content/plugins/wp-statuses/inc/admin/classes/class-wp-statuses-admin.php on line 630
```

This fixes that by getting labels from the `publish` status rather than the non-existent `future` status labels.