### PR TITLE
Remove dependency for composer installers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     ],
     "minimum-stability": "stable",
     "require": {
-      "php": ">=5.3.2",
-      "composer/installers": "~v1.0.12"
+      "php": ">=5.3.2"
     }
 }


### PR DESCRIPTION
The dependency for composer installers is unnecessary at this level. 
The project that includes wp-statuses should have composer installers required - but that is not the job for this plugin to ask for it. 

This requirement brings my setup in trouble as this plugins composer.json requires a very specific composer installer version that is outdated.