### PR TITLE
Hotfix for fatal error on WP 5.7 due to private _builtin property

### DIFF
--- a/inc/core/classes/class-wp-statuses-core-status.php
+++ b/inc/core/classes/class-wp-statuses-core-status.php
@@ -53,7 +53,7 @@ class WP_Statuses_Core_Status {
 	 *
 	 * @var bool
 	 */
-	private $_builtin = false;
+	public $_builtin = false;
 
 	/**
 	 * Whether posts of this status should be shown


### PR DESCRIPTION
This makes the `WP_Statuses_Core_Status::_builtin` property public, so it is accessible by `is_post_status_viewable()` (new in WP 5.7). This resolves fatal errors that made the post list inaccessible if the plugin was active, fixing #51.