### PR TITLE
Replace the deprecated block_editor_preload_paths filter

### DIFF
--- a/inc/admin/classes/class-wp-statuses-admin.php
+++ b/inc/admin/classes/class-wp-statuses-admin.php
@@ -88,7 +88,7 @@ class WP_Statuses_Admin {
 		if ( function_exists( 'register_block_type' ) )  {
 			add_action( 'init',                        array( $this, 'register_block_editor_script' ), 1001 );
 			add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_asset' ), 10 );
-			add_filter( 'block_editor_preload_paths',  array( $this, 'preload_path' ), 10 );
+			add_filter( 'block_editor_rest_api_preload_paths',  array( $this, 'preload_path' ), 10 );
 		}
 	}
 

--- a/inc/admin/classes/class-wp-statuses-admin.php
+++ b/inc/admin/classes/class-wp-statuses-admin.php
@@ -88,7 +88,11 @@ class WP_Statuses_Admin {
 		if ( function_exists( 'register_block_type' ) )  {
 			add_action( 'init',                        array( $this, 'register_block_editor_script' ), 1001 );
 			add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_asset' ), 10 );
-			add_filter( 'block_editor_rest_api_preload_paths',  array( $this, 'preload_path' ), 10 );
+			if ( function_exists( 'block_editor_rest_api_preload' ) ) {
+				add_filter( 'block_editor_rest_api_preload_paths', array( $this, 'preload_path' ), 10 );
+			} else {
+				add_filter( 'block_editor_preload_paths', array( $this, 'preload_path' ), 10 );
+			}
 		}
 	}
 


### PR DESCRIPTION
Hi @ibes, thanks for your work with this plugin.

I'm submitting this PR to update a deprecated function in WP 5.8 released on 20th of this month.
Reference: https://make.wordpress.org/core/2021/06/16/block-editor-api-changes-to-support-multiple-admin-screens-in-wp-5-8/

Glad if you can merge it and release an updated version.
Thanks
