### PR TITLE
Ensure the REST API status hijack is only applied in the admin

### DIFF
--- a/inc/core/functions.php
+++ b/inc/core/functions.php
@@ -539,7 +539,9 @@ function wp_statuses_rest_prepare_for_response( WP_REST_Response $response, WP_P
 	}
 
 	// Always trick the Block Editor so that is uses the "Update" major action button.
-	$post_type['status'] = 'private';
+	if ( is_admin() ) {
+		$post_type['status'] = 'private';
+	}
 
 	$response->set_data( $post_type );
 


### PR DESCRIPTION
Hey @imath,

Thanks so much for making and maintaining this plugin and for all your open source work! 🙏🏻  I'm currently using this plugin for the first time on a client site and I noticed a little bug. When I create posts with the REST API for my client I could see that the post status was always being returned as `status": "private"` when I received the `201` response from the REST API. e.g.

<img width="1058" alt="Postman_2022-04-14_11-05-13" src="https://user-images.githubusercontent.com/1377956/163293998-6d7ceed0-62a4-499c-8288-454a06fe1d55.png">

After some digging I found where you are setting this so that you get the "Update" button to show in Gutenberg. Ideally I think it's better to wrap this in a check to see if we're in the admin area that way the `201` responses from WordPress via external calls to the REST API will return the correct status when a post is created. e.g.

<img width="1055" alt="Postman_2022-04-14_11-09-53" src="https://user-images.githubusercontent.com/1377956/163294408-8b6029fc-4929-4194-b677-eba1acfbb652.png">

I should also note that I did check to make sure this maintains backwards compatibility in the block editor and it does 😁 

Hopefully in the future we might be able to be able to extend the `PostPublishButton` component to get the Publish button working for this plugin as well!