### PR TITLE
fix: should use a timezoned date

### DIFF
--- a/src/sidebar/sidebar.js
+++ b/src/sidebar/sidebar.js
@@ -141,7 +141,7 @@ class WPStatusesPanel extends Component {
 		const needsPassword = 'password' === currentStatus;
 		const hasPublishAction = get( currentPost, [ '_links', 'wp:action-publish' ], false );
 
-		if ( isInTheFuture( currentPost.date_gmt ) && 'future' !== currentStatus ) {
+		if ( isInTheFuture( currentPost.date ) && 'future' !== currentStatus ) {
 			currentStatus = 'future';
 			onUpdateStatus( currentStatus );
 		}


### PR DESCRIPTION
* https://developer.wordpress.org/block-editor/reference-guides/packages/packages-date/#isinthefuture
![Captura de Tela 2022-06-23 às 14 24 01](https://user-images.githubusercontent.com/7463100/175358794-f1770b22-e0dc-44d7-b6a8-d786b57a4e68.png)

