### PR TITLE
Make sure lodash is enqueued declaring the dependency

### DIFF
--- a/inc/admin/classes/class-wp-statuses-admin.php
+++ b/inc/admin/classes/class-wp-statuses-admin.php
@@ -768,6 +768,7 @@ class WP_Statuses_Admin {
 				'wp-edit-post',
 				'wp-i18n',
 				'wp-plugins',
+				'lodash',
 			),
 			wp_statuses_version()
 		);


### PR DESCRIPTION
Using WordPress trunk, I noticed the statuses dropdown wasn't generated due to the lack of lodash.

Fixes #83