### PR TITLE
Do not use `WP_DEBUG` to check whether testing script needs to be loaded or not

### DIFF
--- a/wp-statuses.php
+++ b/wp-statuses.php
@@ -166,7 +166,7 @@ final class WP_Statuses {
 		 * @param  bool $value True to have a demo of the custom status.
 		 *                     False otherwise.
 		 */
-		if ( apply_filters( 'wp_statuses_use_custom_status', WP_DEBUG ) ) {
+		if ( apply_filters( 'wp_statuses_use_custom_status', false ) ) {
 			require $this->inc_dir . 'core/custom.php';
 		}
 	}


### PR DESCRIPTION
Fixes #87