### PR TITLE
Run wp_statuses_register function on change_locale hook

### DIFF
--- a/wp-statuses.php
+++ b/wp-statuses.php
@@ -179,6 +179,7 @@ final class WP_Statuses {
 	private function setup_hooks() {
 		add_action( 'init', 'wp_statuses_register_password_protected',   10 );
 		add_action( 'init', 'wp_statuses_register',                    1000 );
+		add_action( 'change_locale', 'wp_statuses_register',             10 );
 
 		// Boot the Admin
 		if ( is_admin() ) {


### PR DESCRIPTION
Fixes https://github.com/imath/wp-statuses/issues/89.

Note: Error did only occur when editing a post, not when viewing dashboard and so on.

